### PR TITLE
remove unprotected access to subview

### DIFF
--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -86,7 +86,6 @@
     _navigationController.toolbar.translucent = YES;
     _navigationController.toolbar.barTintColor = _toolbarBarTintColor;
     _navigationController.toolbar.tintColor = _toolbarTintColor;
-    [(UIView*)[_navigationController.toolbar.subviews objectAtIndex:0] setAlpha:0.75f];  // URGH - I know!
     
     _navigationController.navigationBar.backgroundColor = _navigationBarBackgroundColor;
     _navigationController.navigationBar.tintColor = _navigationBarTintColor;


### PR DESCRIPTION
The subviews array of the toolbar is very likely to be empty on iOS10, and no protection of objectAtIndex is being used, causing an index out of bound array. 

We opted to remove the line of code entirely as the `setAlpha` was not affecting the app.
